### PR TITLE
Issue #37: ADB Object is empty

### DIFF
--- a/sdks/Cordova/ADBMobile/Shared/ADB_Helper.js
+++ b/sdks/Cordova/ADBMobile/Shared/ADB_Helper.js
@@ -17,8 +17,7 @@
 *
 **************************************************************************/
 var ADB = (function () {
-		var ADB = {
-		};
+    var ADB = (typeof exports !== 'undefined') && exports || {};
 
 	ADB.doNothing = function () {};
 


### PR DESCRIPTION
Going back to the old way of setting up the ADB object to support phonegap plugin add users.