### PR TITLE
Issue #38: Package name incorrect for Android

### DIFF
--- a/sdks/Cordova/ADBMobile/Android/ADBMobile_PhoneGap.java
+++ b/sdks/Cordova/ADBMobile/Android/ADBMobile_PhoneGap.java
@@ -1,4 +1,4 @@
-package com.sample.phonegap;
+package com.adobe;
 
 import android.location.Location;
 import org.apache.cordova.CordovaInterface;


### PR DESCRIPTION
The plugin.xml file shows the path to the ADBMobile_PhoneGap class to be com.adobe not com.sample.phonegap. If the package names don't match then cordova.exec() will not be able to call the correct class' methods.