### PR TITLE
Remove ADBMobileConfig.json from the podspec's preserved paths

### DIFF
--- a/AdobeMobileSDK.podspec
+++ b/AdobeMobileSDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Adobe-Marketing-Cloud/mobile-services.git", :tag => "v4.5.2-cocoapod" }
 
   s.source_files  = "AdobeMobileLibrary/*.h"
-  s.preserve_paths = "AdobeMobileLibrary/libAdobeMobile.a", "AdobeMobileLibrary/ADBMobileConfig.json"
+  s.preserve_paths = "AdobeMobileLibrary/libAdobeMobile.a"
   s.frameworks = "UIKit", "SystemConfiguration"
   s.libraries = "AdobeMobile","sqlite3.0"
   s.requires_arc = false


### PR DESCRIPTION
I've tested the change, works fine. The podspec also lints:
```
mobile-services|cocoapod⚡ ⇒ pod lib lint
 -> AdobeMobileSDK (4.5.2)
    - NOTE  |  ld: warning: directory not found for option '-LAdobeMobileSDK/AdobeMobileLibrary'
AdobeMobileSDK passed validation.
```