### PR TITLE
Add NPM ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+samples/
+sdks/BB10/
+sdks/Unity/
+sdks/Windows/
+sdks/Windows8/
+sdks/Xamarin/


### PR DESCRIPTION
I'm adding an NPM ignore file to the project. It will keep the samples and sdks not supported by the PhoneGap plugin from being added to NPM. This will make the download of the plugin much quicker.