### PR TITLE
Bug fix: activity & receiver elements need their own config-file block

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,8 +34,10 @@
 			 </feature>
 		 </config-file>
 		 <config-file target="AndroidManifest.xml" parent="/manifest">
-	         <uses-permission android:name="android.permission.INTERNET" />
-	         <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+	         	<uses-permission android:name="android.permission.INTERNET" />
+	         	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+		 </config-file>
+		 <config-file target="AndroidManifest.xml" parent="/manifest/application">
 			 <activity android:name="com.adobe.mobile.MessageFullScreenActivity" android:theme="@android:style/Theme.Translucent" />
 			 <receiver android:name="com.adobe.mobile.MessageNotificationHandler" />
 		 </config-file>


### PR DESCRIPTION
Hey there, I'm getting an error when I compile my app with your plugin:
> Error: The &lt;activity&gt; element must be a direct child of the &lt;application&gt; element [WrongManifestParent]
> &lt;activity android:name="com.adobe.mobile.MessageFullScreenActivity" android:theme="@android:style/Theme.Translucent" /&gt;
> Error: The &lt;receiver&gt; element must be a direct child of the &lt;application&gt; element [WrongManifestParent]
> &lt;receiver android:name="com.adobe.mobile.MessageNotificationHandler" /&gt;

I've traced this down to a mistake in the plugin.xml file. For reference, here's an older version of this code which worked ([from 12/3/2015, line 36](https://github.com/Adobe-Marketing-Cloud/mobile-services/blob/cbda9c14989437f911b259a7621460c000140e3e/plugin.xml#L36)):

    <config-file target="AndroidManifest.xml" parent="/manifest">
        <uses-permission android:name="android.permission.INTERNET" />
        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
    </config-file>

And here's the recent version of that same block of code ([from 1/21/2016, line 36](https://github.com/Adobe-Marketing-Cloud/mobile-services/blob/601dbee5c7c02a22dd208076a31dd612a94c543e/plugin.xml#L36)). Note the addition of the activity & receiver elements, which under this instruction get incorrectly added to the manifest element:

    <config-file target="AndroidManifest.xml" parent="/manifest">
        <uses-permission android:name="android.permission.INTERNET"/>
        <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
        <activity android:name="com.adobe.mobile.MessageFullScreenActivity" android:theme="@android:style/Theme.Translucent"/>
        <receiver android:name="com.adobe.mobile.MessageNotificationHandler"/>
    </config-file>

I've updated plugin.xml to shift those activity & receiver elements into a new &lt;config-file&gt; element, which targets parent="/manifest/application", and I am no longer receiving the error when I compile, and my AndroidManifest.xml now has the correct structure.