### PR TITLE
json format does not allow two dots in numbers

### DIFF
--- a/sdks/package.json
+++ b/sdks/package.json
@@ -14,8 +14,8 @@
 			"xboxone": null,
 			"blackberry": "4.0.0",
 			"phonegap": null,
-			"unity": 4.4.2,
-			"xamarin": 4.4.2
+			"unity": "4.4.2",
+			"xamarin": "4.4.2"
 		},
 		"sample-apps": {
 			"ios": "1.1",


### PR DESCRIPTION
A number in json format can have one dot at most: http://www.json.org/