### PR TITLE
Correct custom element name on line 33

### DIFF
--- a/samples/mobile-web/amphtml/amp_analytics/amp_analytics_iframe_example1.amp.html
+++ b/samples/mobile-web/amphtml/amp_analytics/amp_analytics_iframe_example1.amp.html
@@ -30,7 +30,7 @@
 	}
 	</style>
 	<script async src="https://cdn.ampproject.org/v0.js"></script>
-	<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+	<script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
 </head>
 <body>
   <amp-analytics type="adobeanalytics_nativeConfig">


### PR DESCRIPTION
The custom element for "amp-analytics-0.1.js" was changed  from "amp-iframe" to "amp-analytics"