### PR TITLE
Cordova 8 Support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -42,6 +42,6 @@
 			 <receiver android:name="com.adobe.mobile.MessageNotificationHandler" />
 		 </config-file>
 		 <source-file src="sdks/Cordova/ADBMobile/Android/ADBMobile_PhoneGap.java" target-dir="src/com/adobe/" />
-		 <source-file src="sdks/Android/AdobeMobileLibrary/adobeMobileLibrary-4.16.0.jar" target-dir="libs" />
+		 <source-file src="sdks/Android/AdobeMobileLibrary/adobeMobileLibrary-4.16.0.jar" target-dir="app/libs" />
 	 </platform>
 </plugin>


### PR DESCRIPTION
This PR Resolves issue #281

As per new cordova 8 ecosystem libraries should be copied to `app\libs` not to `libs`

look at below link for more info
https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html